### PR TITLE
fix(deps): ignore sort-package-json >=3.7 (drops Node 20 support)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "daily"
     cooldown: 
       default-days: 7  
+    ignore:
+      - dependency-name: "sort-package-json"
+        versions: [">=3.7.0"]
     groups:
       all-dependencies:
         patterns:


### PR DESCRIPTION
sort-package-json 3.7.0 sets `engines: node>=22`. This repo declares `engines: node>=20` and runs `sort-package-json` in its `prepare` script, which runs during `npm ci` on the Node 20 CI leg -- crashing with `1 file could not be sorted` (exit 2). That single bad dep broke the Dependabot CI.

Pin below 3.7.0 until Node 20 is dropped from engines/CI.

-- TARS